### PR TITLE
feat: Support execution without specifying the current version

### DIFF
--- a/sembump.sh
+++ b/sembump.sh
@@ -36,8 +36,8 @@ function read_update_type() {
 
 function bumpup_version() {
   update_type="$1"
-  is_develop="$2"
-  current_version="$3"
+  current_version="$2"
+  is_develop="$3"
   IFS=. read -r major minor patch <<<"$current_version"
   if [ "$is_develop" = '--develop' ] && [ "$major" != '0' ]; then
     echo 'The major version of the development version must be 0.' 1>&2
@@ -93,6 +93,9 @@ while (($# > 0)); do
   esac
   shift
 done
+if [ "$CURRENT_VERSION" = '0.0.0' ] && [ -z "$develop_option" ]; then
+  CURRENT_VERSION='1.0.0'
+fi
 
 export -f bumpup_version
 if [ -p /dev/stdin ]; then
@@ -101,4 +104,4 @@ else
   echo "$@"
 fi |
   read_update_type |
-  xargs -I{} bash -c "bumpup_version {} $develop_option $CURRENT_VERSION"
+  xargs -I{} bash -c "bumpup_version {} $CURRENT_VERSION $develop_option"

--- a/sembump.sh
+++ b/sembump.sh
@@ -58,9 +58,9 @@ function reduce_update_type() {
 }
 
 function bumpup_version() {
-  current_version="$1"
-  update_type="$2"
-  is_develop="$3"
+  update_type="$1"
+  is_develop="$2"
+  current_version="$3"
   IFS=. read -r major minor patch <<<"$current_version"
   if [ "$is_develop" = '--develop' ] && [ "$major" != '0' ]; then
     echo 'The major version of the development version must be 0.' 1>&2
@@ -91,15 +91,16 @@ function bumpup_version() {
   esac
 }
 
-DEVELOP=''
+CURRENT_VERSION="0.0.0"
+args=()
 while (($# > 0)); do
   case $1 in
   -d | --develop)
-    if [[ -n "$DEVELOP" ]]; then
+    if printf '%s\n' "${args[@]}" | grep -qx -- '--develop'; then
       echo "Duplicated 'option'." 1>&2
       exit 1
     fi
-    DEVELOP='--develop'
+    args+=('--develop')
     ;;
   -*)
     echo "invalid option"
@@ -111,6 +112,7 @@ while (($# > 0)); do
   esac
   shift
 done
+args+=("$CURRENT_VERSION")
 
 export -f bumpup_version
 if [ -p /dev/stdin ]; then
@@ -120,4 +122,4 @@ else
 fi |
   read_update_type |
   reduce_update_type |
-  xargs -I{} bash -c "bumpup_version $CURRENT_VERSION {} $DEVELOP"
+  xargs -I{} bash -c "bumpup_version {} ${args[*]}"

--- a/sembump.sh
+++ b/sembump.sh
@@ -92,15 +92,15 @@ function bumpup_version() {
 }
 
 CURRENT_VERSION="0.0.0"
-args=()
+develop_option=''
 while (($# > 0)); do
   case $1 in
   -d | --develop)
-    if printf '%s\n' "${args[@]}" | grep -qx -- '--develop'; then
+    if [[ -n "$develop_option" ]]; then
       echo "Duplicated 'option'." 1>&2
       exit 1
     fi
-    args+=('--develop')
+    develop_option='--develop'
     ;;
   -*)
     echo "invalid option"
@@ -112,7 +112,6 @@ while (($# > 0)); do
   esac
   shift
 done
-args+=("$CURRENT_VERSION")
 
 export -f bumpup_version
 if [ -p /dev/stdin ]; then
@@ -122,4 +121,4 @@ else
 fi |
   read_update_type |
   reduce_update_type |
-  xargs -I{} bash -c "bumpup_version {} ${args[*]}"
+  xargs -I{} bash -c "bumpup_version {} $develop_option $CURRENT_VERSION"

--- a/sembump.sh
+++ b/sembump.sh
@@ -70,6 +70,10 @@ function bumpup_version() {
     echo "1.0.0"
     return 0
   fi
+  if [ "$is_develop" == '--develop' ] && [ "$current_version" = '0.0.0' ]; then
+    echo '0.1.0'
+    return 0
+  fi
   case "$update_type" in
   "major")
     if [ "$is_develop" = '--develop' ]; then


### PR DESCRIPTION
Add the following features:
+ Treat the current version as 0.0.0 by default.

Add the following fixes:
+ The first Patch update from 0.0.0 should be 0.1.0.
+ The default version without the develop option is 1.0.0.